### PR TITLE
fix: drizzle-zod interests array of enums

### DIFF
--- a/server/src/router/v1/index.ts
+++ b/server/src/router/v1/index.ts
@@ -16,7 +16,9 @@ const v1App = new OpenAPIHono<Context>();
 v1App.route('/auth', authRouter);
 
 // Users
-const userSchema = createSelectSchema(users);
+const userSchema = createSelectSchema(users).extend({
+	interests: z.array(z.enum(['web development', 'machine learning', 'cloud computing', 'artificial intelligence'])),
+});
 
 v1App.openapi(
 	createRoute({
@@ -43,7 +45,7 @@ v1App.openapi(
 		const formattedUsers = foundUsers.map(user => ({
 			...user,
 			createdAt: user.createdAt.toISOString(),
-			interests: user.interests[0],
+			interests: user.interests,
 		}));
 		return c.json({ users: formattedUsers }, HttpStatusCodes.OK);
 	},
@@ -77,7 +79,6 @@ v1App.openapi(
 		return c.json({ projects: foundProjects }, HttpStatusCodes.OK);
 	},
 );
-
 
 // Majors
 const majorSchema = createSelectSchema(majors);


### PR DESCRIPTION
this fixes the issue where the `createSelectSchema` provided by `drizzle-zod` couldn't recognize the fact that `interests` is a field with array of enums and not just a single enum value